### PR TITLE
fix: Implement deleteRemoteOnExpire in cleanupExpired

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mzedstudio/uploadthingtrack",
   "description": "UploadThing file tracking, access control, and cleanup for Convex.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -213,6 +213,12 @@ export class UploadThingFiles {
 
   /**
    * Delete expired file records in batches. Use `dryRun` to preview.
+   *
+   * When `deleteRemoteOnExpire` is enabled in config, also calls the
+   * UploadThing API to delete files from their servers before removing
+   * local records. If remote deletion fails, local records are preserved
+   * so the next run can retry. Check `remoteDeleteFailed` and
+   * `remoteDeleteError` in the return value for details.
    */
   async cleanupExpired(
     ctx: ActionCtx,

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -38,7 +38,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "action",
         "internal",
         { batchSize?: number; dryRun?: boolean },
-        { deletedCount: number; hasMore: boolean; keys: Array<string> },
+        {
+          deletedCount: number;
+          hasMore: boolean;
+          keys: Array<string>;
+          remoteDeleteError?: string;
+          remoteDeleteFailed?: boolean;
+          remoteDeletedCount?: number;
+        },
         Name
       >;
     };

--- a/src/component/cleanup.ts
+++ b/src/component/cleanup.ts
@@ -2,6 +2,42 @@ import { action } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 
+const UT_DELETE_ENDPOINT = "https://api.uploadthing.com/v6/deleteFiles";
+const UT_DELETE_CHUNK_SIZE = 100;
+
+async function deleteRemoteFiles(
+  apiKey: string,
+  fileKeys: string[],
+): Promise<{ success: boolean; error?: string }> {
+  for (let i = 0; i < fileKeys.length; i += UT_DELETE_CHUNK_SIZE) {
+    const chunk = fileKeys.slice(i, i + UT_DELETE_CHUNK_SIZE);
+    try {
+      const response = await fetch(UT_DELETE_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-uploadthing-api-key": apiKey,
+        },
+        body: JSON.stringify({ fileKeys: chunk }),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "unknown");
+        return {
+          success: false,
+          error: `UploadThing API returned ${response.status}: ${text}`,
+        };
+      }
+    } catch (err: unknown) {
+      return {
+        success: false,
+        error: `UploadThing API request failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+  return { success: true };
+}
+
 export const cleanupExpired = action({
   args: {
     batchSize: v.optional(v.number()),
@@ -11,14 +47,20 @@ export const cleanupExpired = action({
     deletedCount: v.number(),
     keys: v.array(v.string()),
     hasMore: v.boolean(),
+    remoteDeletedCount: v.optional(v.number()),
+    remoteDeleteFailed: v.optional(v.boolean()),
+    remoteDeleteError: v.optional(v.string()),
   }),
   handler: async (ctx, args): Promise<{
     deletedCount: number;
     keys: string[];
     hasMore: boolean;
+    remoteDeletedCount?: number;
+    remoteDeleteFailed?: boolean;
+    remoteDeleteError?: string;
   }> => {
     const globals = await ctx.runQuery(internal.config.getGlobalsInternal, {});
-    const limit = args.batchSize ?? (globals as any).deleteBatchSize ?? 100;
+    const limit = args.batchSize ?? globals.deleteBatchSize ?? 100;
 
     const expired = (await ctx.runQuery(internal.queries.expiredBatch, {
       now: Date.now(),
@@ -27,14 +69,50 @@ export const cleanupExpired = action({
 
     const keys = expired.map((item) => item.key);
 
-    if (!args.dryRun && keys.length > 0) {
-      await ctx.runMutation(internal.files.deleteFilesByKey, { keys });
+    if (args.dryRun || keys.length === 0) {
+      return {
+        deletedCount: 0,
+        keys,
+        hasMore: expired.length >= limit,
+      };
     }
 
+    let remoteDeletedCount: number | undefined;
+    let remoteDeleteFailed: boolean | undefined;
+    let remoteDeleteError: string | undefined;
+
+    if (globals.deleteRemoteOnExpire) {
+      if (!globals.uploadthingApiKey) {
+        remoteDeleteFailed = true;
+        remoteDeleteError =
+          "deleteRemoteOnExpire is enabled but no uploadthingApiKey is configured";
+      } else {
+        const result = await deleteRemoteFiles(globals.uploadthingApiKey, keys);
+        if (result.success) {
+          remoteDeletedCount = keys.length;
+        } else {
+          // Remote deletion failed — preserve local records so the next run can retry
+          return {
+            deletedCount: 0,
+            keys,
+            hasMore: expired.length >= limit,
+            remoteDeletedCount: 0,
+            remoteDeleteFailed: true,
+            remoteDeleteError: result.error,
+          };
+        }
+      }
+    }
+
+    await ctx.runMutation(internal.files.deleteFilesByKey, { keys });
+
     return {
-      deletedCount: args.dryRun ? 0 : keys.length,
+      deletedCount: keys.length,
       keys,
       hasMore: expired.length >= limit,
+      ...(remoteDeletedCount !== undefined && { remoteDeletedCount }),
+      ...(remoteDeleteFailed !== undefined && { remoteDeleteFailed }),
+      ...(remoteDeleteError !== undefined && { remoteDeleteError }),
     };
   },
 });


### PR DESCRIPTION
## Summary

- `cleanupExpired` now checks the `deleteRemoteOnExpire` config flag and calls the UploadThing API (`POST /v6/deleteFiles`) to delete remote files before removing local records
- If remote deletion fails, local records are preserved so the next cleanup run can retry automatically
- If `deleteRemoteOnExpire` is enabled but no API key is configured, cleanup still proceeds locally with a warning in the return value
- New optional return fields: `remoteDeletedCount`, `remoteDeleteFailed`, `remoteDeleteError`

Closes #2

## Test plan

- [x] Existing 18 tests pass unchanged (backward compatible)
- [x] New test: `deleteRemoteOnExpire` true but no API key — local records deleted, warning returned
- [x] New test: remote deletion fails (fake key) — local records preserved for retry
- [x] New test: `dryRun` with `deleteRemoteOnExpire` — no remote call attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote file deletion capability with configurable batching and error recovery.

* **Improvements**
  * Enhanced error handling for failed remote deletions with detailed error messages.

* **Documentation**
  * Expanded documentation on cleanup behavior and remote deletion retry logic.

* **Tests**
  * Added test coverage for cleanup operations and dry-run scenarios.

* **Chores**
  * Bumped version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->