### PR TITLE
feat: Expose public deleteFiles mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mzedstudio/uploadthingtrack",
   "description": "UploadThing file tracking, access control, and cleanup for Convex.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -212,6 +212,17 @@ export class UploadThingFiles {
   }
 
   /**
+   * Delete specific file records by their UploadThing keys.
+   * Returns the number of records actually deleted.
+   */
+  async deleteFiles(
+    ctx: MutationCtx,
+    args: { keys: string[] },
+  ) {
+    return await ctx.runMutation(this.component.files.deleteFiles, args);
+  }
+
+  /**
    * Delete expired file records in batches. Use `dryRun` to preview.
    *
    * When `deleteRemoteOnExpire` is enabled in config, also calls the

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -83,6 +83,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       >;
     };
     files: {
+      deleteFiles: FunctionReference<
+        "mutation",
+        "internal",
+        { keys: Array<string> },
+        number,
+        Name
+      >;
       setFileAccess: FunctionReference<
         "mutation",
         "internal",

--- a/src/component/files.ts
+++ b/src/component/files.ts
@@ -174,6 +174,27 @@ export const setFolderAccess = mutation({
   },
 });
 
+export const deleteFiles = mutation({
+  args: {
+    keys: v.array(v.string()),
+  },
+  returns: v.number(),
+  handler: async (ctx, args) => {
+    let count = 0;
+    for (const key of args.keys) {
+      const existing = await ctx.db
+        .query("files")
+        .withIndex("by_key", (q) => q.eq("key", key))
+        .unique();
+      if (existing) {
+        await ctx.db.delete(existing._id);
+        count++;
+      }
+    }
+    return count;
+  },
+});
+
 export const deleteFilesByKey = internalMutation({
   args: {
     keys: v.array(v.string()),

--- a/tests/uploadthing_file_tracker.test.ts
+++ b/tests/uploadthing_file_tracker.test.ts
@@ -400,6 +400,37 @@ describe("uploadthing file tracker", () => {
     expect(result.deletedCount).toBe(1);
   });
 
+  test("deleteFiles removes specific records and returns count", async () => {
+    const t = makeTest();
+
+    await t.mutation("files:upsertFile", {
+      file: { ...baseFile, key: "del_1" },
+      userId: "owner",
+    });
+    await t.mutation("files:upsertFile", {
+      file: { ...baseFile, key: "del_2" },
+      userId: "owner",
+    });
+    await t.mutation("files:upsertFile", {
+      file: { ...baseFile, key: "del_3" },
+      userId: "owner",
+    });
+
+    const count = await t.mutation("files:deleteFiles", {
+      keys: ["del_1", "del_3", "nonexistent"],
+    });
+
+    expect(count).toBe(2);
+
+    const remaining = await t.query("queries:listFiles", {
+      ownerUserId: "owner",
+      viewerUserId: "owner",
+    });
+
+    expect(remaining.length).toBe(1);
+    expect(remaining[0]?.key).toBe("del_2");
+  });
+
   test("cleanup warns when deleteRemoteOnExpire is true but no API key", async () => {
     const t = makeTest();
 


### PR DESCRIPTION
## Summary

- Add public `deleteFiles` mutation in `files.ts` — deletes specific file records by key and returns the count of records actually deleted
- Add `deleteFiles` client wrapper method on `UploadThingFiles` class
- Existing internal `deleteFilesByKey` preserved for use by `cleanupExpired`

Closes #3

## Test plan

- [x] All 22 existing tests pass
- [x] New test: inserts 3 files, deletes 2 by key (plus a nonexistent key), verifies count=2 and only the undeleted file remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file deletion functionality allowing you to remove specific files by providing their keys, with confirmation of how many files were successfully deleted.

* **Tests**
  * Added test coverage for the new file deletion feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->