### PR TITLE
feat: Add cross-user listAllFiles query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mzedstudio/uploadthingtrack",
   "description": "UploadThing file tracking, access control, and cleanup for Convex.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -119,6 +119,23 @@ export class UploadThingFiles {
   }
 
   /**
+   * List files across all users with optional filters and access control.
+   */
+  async listAllFiles(
+    ctx: QueryCtx,
+    args: {
+      viewerUserId?: string;
+      mimeType?: string;
+      tag?: string;
+      folder?: string;
+      includeExpired?: boolean;
+      limit?: number;
+    } = {},
+  ) {
+    return await ctx.runQuery(this.component.queries.listAllFiles, args);
+  }
+
+  /**
    * Get the access rule for a specific folder, or `null` if none is set.
    */
   async getFolderRule(

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -198,6 +198,42 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         } | null,
         Name
       >;
+      listAllFiles: FunctionReference<
+        "query",
+        "internal",
+        {
+          folder?: string;
+          includeExpired?: boolean;
+          limit?: number;
+          mimeType?: string;
+          tag?: string;
+          viewerUserId?: string;
+        },
+        Array<{
+          _creationTime: number;
+          _id: string;
+          access?: {
+            allowUserIds?: Array<string>;
+            denyUserIds?: Array<string>;
+            visibility: "public" | "private" | "restricted";
+          };
+          customId?: string;
+          expiresAt?: number;
+          fileType?: string;
+          folder?: string;
+          key: string;
+          metadata?: any;
+          mimeType: string;
+          name: string;
+          replacedAt?: number;
+          size: number;
+          tags?: Array<string>;
+          uploadedAt: number;
+          url: string;
+          userId: string;
+        }>,
+        Name
+      >;
       listFiles: FunctionReference<
         "query",
         "internal",


### PR DESCRIPTION
## Summary

- Add `listAllFiles` query — lists files across all users with access control, filtering by folder/tag/mimeType/expired, and limit-based pagination
- Uses `by_folder` index when folder filter is provided, otherwise table scan ordered desc
- Add `listAllFiles` client wrapper on `UploadThingFiles` class
- Note: `metadata` is already returned by existing queries (`fileDocValidator` includes it) — no changes needed

Closes #6

## Test plan

- [x] All 24 tests pass (22 existing + 2 new)
- [x] New test: cross-user query with public/private access control — viewer sees only public files, owner sees own private files
- [x] New test: `listAllFiles` filters by tag and mimeType correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to list all files with optional filtering by MIME type, tag, and folder, with access control to ensure users only see files they're authorized to access.

* **Tests**
  * Added comprehensive test coverage for file listing functionality, including cross-user access scenarios and filter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->