### PR TITLE
fix: Accept apiKey arg in cleanupExpired as env var fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mzedstudio/uploadthingtrack",
   "description": "UploadThing file tracking, access control, and cleanup for Convex.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "keywords": [
     "convex",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -247,12 +247,17 @@ export class UploadThingFiles {
    * local records. If remote deletion fails, local records are preserved
    * so the next run can retry. Check `remoteDeleteFailed` and
    * `remoteDeleteError` in the return value for details.
+   *
+   * Pass `apiKey` to provide the UploadThing API key directly (e.g.
+   * from `process.env.UPLOADTHING_API_KEY`). Falls back to the key
+   * stored via `setConfig`.
    */
   async cleanupExpired(
     ctx: ActionCtx,
     args: {
       batchSize?: number;
       dryRun?: boolean;
+      apiKey?: string;
     } = {},
   ) {
     return await ctx.runAction(this.component.cleanup.cleanupExpired, args);

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -37,7 +37,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       cleanupExpired: FunctionReference<
         "action",
         "internal",
-        { batchSize?: number; dryRun?: boolean },
+        { apiKey?: string; batchSize?: number; dryRun?: boolean },
         {
           deletedCount: number;
           hasMore: boolean;

--- a/src/component/cleanup.ts
+++ b/src/component/cleanup.ts
@@ -42,6 +42,7 @@ export const cleanupExpired = action({
   args: {
     batchSize: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
+    apiKey: v.optional(v.string()),
   },
   returns: v.object({
     deletedCount: v.number(),
@@ -82,12 +83,14 @@ export const cleanupExpired = action({
     let remoteDeleteError: string | undefined;
 
     if (globals.deleteRemoteOnExpire) {
-      if (!globals.uploadthingApiKey) {
+      const apiKey = args.apiKey ?? globals.uploadthingApiKey;
+      if (!apiKey) {
         remoteDeleteFailed = true;
         remoteDeleteError =
-          "deleteRemoteOnExpire is enabled but no uploadthingApiKey is configured";
+          "deleteRemoteOnExpire is enabled but no uploadthingApiKey is configured. " +
+          "Pass apiKey to cleanupExpired or set it via setConfig.";
       } else {
-        const result = await deleteRemoteFiles(globals.uploadthingApiKey, keys);
+        const result = await deleteRemoteFiles(apiKey, keys);
         if (result.success) {
           remoteDeletedCount = keys.length;
         } else {


### PR DESCRIPTION
## Summary

- `cleanupExpired` now accepts an optional `apiKey` argument, matching the pattern used by `handleCallback`
- The arg takes precedence over the config-stored key (`args.apiKey ?? globals.uploadthingApiKey`)
- Consumers can pass `process.env.UPLOADTHING_API_KEY` from their app-side action without needing `setConfig`
- Improved error message when no key is found from either source
- Updated README to document all features from v0.3.0–v0.4.1

**Note:** Convex components cannot access `process.env` directly, so the env var fallback proposed in the issue is implemented via an arg that the consumer passes from their app code.

Closes #8

## Test plan

- [x] All 25 tests pass (24 existing + 1 new)
- [x] New test: `apiKey` arg bypasses "no key in config" warning and reaches the UT API call
- [x] Existing "no API key" test still passes with updated error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API reference with new methods (listAllFiles, deleteFiles, getFolderRules) and configuration options.
  * Added usage examples for file operations and cleanup patterns.
  * Documented custom metadata and remote cleanup support.

* **New Features**
  * cleanupExpired operation now accepts an optional apiKey parameter for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->